### PR TITLE
Change name from 'rowix' to 'pairpad'.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN go mod download
 COPY ./ ./
 
 # skipcq: DOK-DL3018
-RUN apk add --no-cache bash && go build -o ./rowix-server ./server/main.go
+RUN apk add --no-cache bash && go build -o ./pairpad-server ./server/main.go
 
 EXPOSE 8080
 
-CMD [ "/app/rowix-server" ]
+CMD [ "/app/pairpad-server" ]

--- a/client/main.go
+++ b/client/main.go
@@ -15,8 +15,8 @@ import (
 	"time"
 
 	"github.com/Pallinder/go-randomdata"
-	"github.com/burntcarrot/rowix/client/editor"
-	"github.com/burntcarrot/rowix/crdt"
+	"github.com/burntcarrot/pairpad/client/editor"
+	"github.com/burntcarrot/pairpad/crdt"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"github.com/nsf/termbox-go"
@@ -113,13 +113,13 @@ func main() {
 	}
 
 	// Get log paths based on the home directory.
-	rowixDir := filepath.Join(homeDir, ".rowix")
-	if rowixDirExists(rowixDir) && homeDirExists {
-		logPath = filepath.Join(rowixDir, "rowix.log")
-		debugLogPath = filepath.Join(rowixDir, "rowix-debug.log")
+	pairpadDir := filepath.Join(homeDir, ".pairpad")
+	if pairpadDirExists(pairpadDir) && homeDirExists {
+		logPath = filepath.Join(pairpadDir, "pairpad.log")
+		debugLogPath = filepath.Join(pairpadDir, "pairpad-debug.log")
 	} else {
-		logPath = "rowix.log"
-		debugLogPath = "rowix-debug.log"
+		logPath = "pairpad.log"
+		debugLogPath = "pairpad-debug.log"
 	}
 
 	// open the log file and create if it does not exist
@@ -184,7 +184,7 @@ func main() {
 
 	err = UI(conn)
 	if err != nil {
-		if strings.HasPrefix(err.Error(), "rowix") {
+		if strings.HasPrefix(err.Error(), "pairpad") {
 			fmt.Println("exiting session.")
 			return
 		}
@@ -252,7 +252,7 @@ func handleTermboxEvent(ev termbox.Event, conn *websocket.Conn) error {
 	if ev.Type == termbox.EventKey {
 		switch ev.Key {
 		case termbox.KeyEsc, termbox.KeyCtrlC:
-			return errors.New("rowix: exiting")
+			return errors.New("pairpad: exiting")
 		case termbox.KeyCtrlS:
 			if fileName != "" {
 				err := crdt.Save(fileName, &doc)
@@ -454,16 +454,16 @@ func getMsgChan(conn *websocket.Conn) chan message {
 	return messageChan
 }
 
-func rowixDirExists(rowixDir string) bool {
-	if _, err := os.Stat(rowixDir); err == nil {
+func pairpadDirExists(pairpadDir string) bool {
+	if _, err := os.Stat(pairpadDir); err == nil {
 		return true
 	} else if errors.Is(err, os.ErrNotExist) {
-		err = os.Mkdir(rowixDir, 0744) // skipcq: GSC-G302
+		err = os.Mkdir(pairpadDir, 0744) // skipcq: GSC-G302
 		if err != nil {
 			return false
 		} else {
 			// skipcq: GSC-G302
-			if err = os.Chmod(rowixDir, 0744); err != nil {
+			if err = os.Chmod(pairpadDir, 0744); err != nil {
 				return false
 			} else {
 				return true

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/burntcarrot/rowix
+module github.com/burntcarrot/pairpad
 
 go 1.18
 

--- a/server/main.go
+++ b/server/main.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/burntcarrot/rowix/crdt"
+	"github.com/burntcarrot/pairpad/crdt"
 	"github.com/fatih/color"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
@@ -125,6 +125,7 @@ func handleConn(w http.ResponseWriter, r *http.Request) {
 			err = clientInfo.Conn.WriteJSON(&msg)
 			if err != nil {
 				color.Red("Failed to send docReq: %v\n", err)
+
 				continue
 			}
 			break


### PR DESCRIPTION
Updated Go source code, go.mod file, and Dockerfile to reflect name change. Also re-launched fly app (new server address is pairpad-server.fly.dev). TODO: update goreleaser and README.