### PR TITLE
Cursor updating and scrolling

### DIFF
--- a/client/editor/editor.go
+++ b/client/editor/editor.go
@@ -25,7 +25,7 @@ type Editor struct {
 	// Height represents the terminal's width in characters.
 	Height int
 
-	//ColOff is the number of columns between the start of a line and the left of the editor window
+	// ColOff is the number of columns between the start of a line and the left of the editor window
 	ColOff int
 
 	// RowOff is the number of rows between the beginning of the text and the top of the editor window

--- a/client/editor/editor.go
+++ b/client/editor/editor.go
@@ -8,6 +8,10 @@ import (
 	"github.com/nsf/termbox-go"
 )
 
+type EditorConfig struct {
+	ScrollEnabled bool
+}
+
 // Editor represents the editor's skeleton.
 // The editor is composed of two components:
 // 1. an editable text area; which acts as the primary interactive area.
@@ -41,8 +45,10 @@ type Editor struct {
 }
 
 // NewEditor returns a new instance of the editor.
-func NewEditor(enableScroll bool) *Editor {
-	return &Editor{ScrollEnabled: enableScroll}
+func NewEditor(conf EditorConfig) *Editor {
+	return &Editor{
+		ScrollEnabled: conf.ScrollEnabled,
+	}
 }
 
 // GetText returns the editor's content.

--- a/client/editor/editor.go
+++ b/client/editor/editor.go
@@ -36,11 +36,13 @@ type Editor struct {
 
 	// StatusMsg represents the text displayed in the status bar.
 	StatusMsg string
+
+	ScrollEnabled bool
 }
 
 // NewEditor returns a new instance of the editor.
-func NewEditor() *Editor {
-	return &Editor{}
+func NewEditor(enableScroll bool) *Editor {
+	return &Editor{ScrollEnabled: enableScroll}
 }
 
 // GetText returns the editor's content.
@@ -217,29 +219,31 @@ func (e *Editor) MoveCursor(x, y int) {
 		newCursor = e.calcCursorUp()
 	}
 
-	cx, cy := e.calcCursorXY(newCursor)
+	if e.ScrollEnabled {
+		cx, cy := e.calcCursorXY(newCursor)
 
-	// move the window to adjust for the cursor
-	rowStart := e.GetRowOff()
-	rowEnd := e.GetRowOff() + e.GetHeight() - 1
+		// move the window to adjust for the cursor
+		rowStart := e.GetRowOff()
+		rowEnd := e.GetRowOff() + e.GetHeight() - 1
 
-	if cy <= rowStart { // scroll up
-		e.IncRowOff(cy - rowStart - 1)
-	}
+		if cy <= rowStart { // scroll up
+			e.IncRowOff(cy - rowStart - 1)
+		}
 
-	if cy > rowEnd { // scroll down
-		e.IncRowOff(cy - rowEnd)
-	}
+		if cy > rowEnd { // scroll down
+			e.IncRowOff(cy - rowEnd)
+		}
 
-	colStart := e.GetColOff()
-	colEnd := e.GetColOff() + e.GetWidth()
+		colStart := e.GetColOff()
+		colEnd := e.GetColOff() + e.GetWidth()
 
-	if cx <= colStart { // scroll left
-		e.IncColOff(cx - (colStart + 1))
-	}
+		if cx <= colStart { // scroll left
+			e.IncColOff(cx - (colStart + 1))
+		}
 
-	if cx > colEnd { // scroll right
-		e.IncColOff(cx - colEnd)
+		if cx > colEnd { // scroll right
+			e.IncColOff(cx - colEnd)
+		}
 	}
 
 	// Reset to bounds.

--- a/client/editor/editor.go
+++ b/client/editor/editor.go
@@ -220,20 +220,26 @@ func (e *Editor) MoveCursor(x, y int) {
 	cx, cy := e.calcCursorXY(newCursor)
 
 	// move the window to adjust for the cursor
-	if cy > e.GetRowOff()+e.GetHeight()-1 {
-		e.IncRowOff(1)
+	rowStart := e.GetRowOff()
+	rowEnd := e.GetRowOff() + e.GetHeight() - 1
+
+	if cy <= rowStart { // scroll up
+		e.IncRowOff(cy - rowStart - 1)
 	}
 
-	if cy <= e.GetRowOff() {
-		e.IncRowOff(-1)
+	if cy > rowEnd { // scroll down
+		e.IncRowOff(cy - rowEnd)
 	}
 
-	if cx > e.GetColOff()+e.GetWidth() {
-		e.IncColOff(1)
+	colStart := e.GetColOff()
+	colEnd := e.GetColOff() + e.GetWidth()
+
+	if cx <= colStart { // scroll left
+		e.IncColOff(cx - (colStart + 1))
 	}
 
-	if cx <= e.GetColOff() {
-		e.IncColOff(-1)
+	if cx > colEnd { // scroll right
+		e.IncColOff(cx - colEnd)
 	}
 
 	// Reset to bounds.

--- a/client/editor/editor_test.go
+++ b/client/editor/editor_test.go
@@ -144,13 +144,6 @@ func TestMoveCursor(t *testing.T) {
 			text: []rune("\n\n\n\n\n")},
 		{description: "move down (from empty line to empty line 2)", cursor: 2, y: 1, expectedCursor: 3,
 			text: []rune("\n\n\n\n\n")},
-		//TODO: Tests to add:
-		// moving cursor down at bottom of screen causing scroll
-		// moving cursor up at top causing scroll
-		// test scrolling
-
-		{description: "move down (from empty line to empty line 2)", cursor: 2, y: 1, expectedCursor: 3,
-			text: []rune("\n\n\n\n\n")},
 	}
 
 	e := NewEditor()
@@ -173,8 +166,8 @@ func TestScroll(t *testing.T) {
 	{
 		tests := []struct {
 			description    string
-			scrollX        int
-			scrollY        int
+			x              int
+			y              int
 			colOff         int
 			expectedColOff int
 			rowOff         int
@@ -184,39 +177,36 @@ func TestScroll(t *testing.T) {
 			text           []rune
 		}{
 			{description: "scroll down",
-				scrollY: 1,
-				colOff:  0, expectedColOff: 0,
+				y:      1,
+				colOff: 0, expectedColOff: 0,
 				rowOff: 0, expectedRowOff: 1,
 				cursor: 6, expectedCursor: 8,
 				text: []rune("a\nb\nc\nd\ne")},
 
 			{description: "scroll up",
-				scrollY: -1,
-				colOff:  0, expectedColOff: 0,
+				y:      -1,
+				colOff: 0, expectedColOff: 0,
 				rowOff: 1, expectedRowOff: 0,
 				cursor: 2, expectedCursor: 0,
 				text: []rune("a\nb\nc\nd\ne")},
 
 			{description: "scroll right",
-				scrollX: 1,
-				colOff:  0, expectedColOff: 1,
+				x:      1,
+				colOff: 0, expectedColOff: 1,
 				rowOff: 0, expectedRowOff: 0,
 				cursor: 4, expectedCursor: 5,
 				text: []rune("abcde")},
 
 			{description: "scroll left",
-				scrollX: -1,
-				colOff:  1, expectedColOff: 0,
+				x:      -1,
+				colOff: 1, expectedColOff: 0,
 				rowOff: 0, expectedRowOff: 0,
 				cursor: 1, expectedCursor: 0,
 				text: []rune("abcde")},
-			//TODO: tests to add:
-			// scroll right
-			// scroll left
 		}
 
 		e := NewEditor()
-		e.Width = 4
+		e.Width = 5
 		e.Height = 5
 
 		for _, tc := range tests {
@@ -225,7 +215,7 @@ func TestScroll(t *testing.T) {
 			e.Cursor = tc.cursor
 			e.Text = tc.text
 
-			e.MoveCursor(tc.scrollX, tc.scrollY)
+			e.MoveCursor(tc.x, tc.y)
 
 			gotCursor := e.Cursor
 			expectedCursor := tc.expectedCursor

--- a/client/editor/editor_test.go
+++ b/client/editor/editor_test.go
@@ -19,7 +19,7 @@ func TestAddRune(t *testing.T) {
 		{r: 'd', cursor: 3, expected: []rune{'a', 'b', 'c', 'd', 'e'}},
 	}
 
-	e := NewEditor()
+	e := NewEditor(true)
 
 	for _, tc := range tests {
 		e.Cursor = tc.cursor
@@ -44,7 +44,7 @@ func TestCalcCursorXY(t *testing.T) {
 		{description: "large number", cursor: 100000, expectedX: 5, expectedY: 2},
 	}
 
-	e := NewEditor()
+	e := NewEditor(true)
 	e.Text = []rune("content\ntest")
 
 	for _, tc := range tests {
@@ -146,7 +146,7 @@ func TestMoveCursor(t *testing.T) {
 			text: []rune("\n\n\n\n\n")},
 	}
 
-	e := NewEditor()
+	e := NewEditor(true)
 
 	for _, tc := range tests {
 		e.Cursor = tc.cursor
@@ -219,7 +219,7 @@ func TestScroll(t *testing.T) {
 				text: []rune("abcdefgh\nijk")},
 		}
 
-		e := NewEditor()
+		e := NewEditor(true)
 		e.Width = 5
 		e.Height = 5
 

--- a/client/editor/editor_test.go
+++ b/client/editor/editor_test.go
@@ -82,6 +82,7 @@ func TestMoveCursor(t *testing.T) {
 			text: []rune("foo\n")},
 		{description: "move forward (out of bounds)", cursor: 3, x: 2, expectedCursor: 4,
 			text: []rune("foo\n")},
+
 		// test vertical movement
 		{description: "move up", cursor: 6, y: -1, expectedCursor: 2,
 			text: []rune("foo\nbar")},
@@ -146,6 +147,10 @@ func TestMoveCursor(t *testing.T) {
 		//TODO: Tests to add:
 		// moving cursor down at bottom of screen causing scroll
 		// moving cursor up at top causing scroll
+		// test scrolling
+
+		{description: "move down (from empty line to empty line 2)", cursor: 2, y: 1, expectedCursor: 3,
+			text: []rune("\n\n\n\n\n")},
 	}
 
 	e := NewEditor()
@@ -168,50 +173,59 @@ func TestScroll(t *testing.T) {
 	{
 		tests := []struct {
 			description    string
-			scrollAmt      int
+			scrollX        int
+			scrollY        int
+			colOff         int
+			expectedColOff int
 			rowOff         int
 			expectedRowOff int
 			cursor         int
 			expectedCursor int
-			// runeAtCursor rune
-			// expectedRuneAtCursor rune
-			text []rune
+			text           []rune
 		}{
-			{description: "normal scroll down",
-				scrollAmt: 1,
-				rowOff:    0, expectedRowOff: 1,
-				cursor: 0, expectedCursor: 2,
-				// runeAtCursor: a, expectedRuneAtCursor: ,
-				text: []rune("a\nb\nc\nd\ne\nf\ng\n")},
+			{description: "scroll down",
+				scrollY: 1,
+				colOff:  0, expectedColOff: 0,
+				rowOff: 0, expectedRowOff: 1,
+				cursor: 6, expectedCursor: 8,
+				text: []rune("a\nb\nc\nd\ne")},
 
-			{description: "normal scroll up",
-				scrollAmt: -1,
-				rowOff:    1, expectedRowOff: 0,
-				cursor: 2, expectedCursor: 2,
-				text: []rune("a\nb\nc\nd\ne\nf\ng\n")},
+			{description: "scroll up",
+				scrollY: -1,
+				colOff:  0, expectedColOff: 0,
+				rowOff: 1, expectedRowOff: 0,
+				cursor: 2, expectedCursor: 0,
+				text: []rune("a\nb\nc\nd\ne")},
 
-			{description: "normal scroll up",
-				scrollAmt: -1,
-				rowOff:    1, expectedRowOff: 0,
-				cursor: 0, expectedCursor: 0,
-				text: []rune("a\nb\nc\nd\ne\nf\ng\n")},
+			{description: "scroll right",
+				scrollX: 1,
+				colOff:  0, expectedColOff: 1,
+				rowOff: 0, expectedRowOff: 0,
+				cursor: 4, expectedCursor: 5,
+				text: []rune("abcde")},
+
+			{description: "scroll left",
+				scrollX: -1,
+				colOff:  1, expectedColOff: 0,
+				rowOff: 0, expectedRowOff: 0,
+				cursor: 1, expectedCursor: 0,
+				text: []rune("abcde")},
 			//TODO: tests to add:
-			// scrolling down with short text is rejected
-			// scrolling up at top is rejected
-			// scrolling down with cursor at top keeps cursor in same place
-			// scrolling
+			// scroll right
+			// scroll left
 		}
 
 		e := NewEditor()
-		e.Width = 80
+		e.Width = 4
 		e.Height = 5
 
 		for _, tc := range tests {
+			e.ColOff = tc.colOff
 			e.RowOff = tc.rowOff
 			e.Cursor = tc.cursor
 			e.Text = tc.text
 
-			e.Scroll(tc.scrollAmt)
+			e.MoveCursor(tc.scrollX, tc.scrollY)
 
 			gotCursor := e.Cursor
 			expectedCursor := tc.expectedCursor
@@ -226,56 +240,13 @@ func TestScroll(t *testing.T) {
 			if !cmp.Equal(gotRowOff, expectedRowOff) {
 				t.Errorf("(%s) Wrong offset: got != expected, diff: %v\n", tc.description, cmp.Diff(gotRowOff, expectedRowOff))
 			}
+
+			gotColOff := e.ColOff
+			expectedColOff := tc.expectedColOff
+
+			if !cmp.Equal(gotColOff, expectedColOff) {
+				t.Errorf("(%s) Wrong offset: got != expected, diff: %v\n", tc.description, cmp.Diff(gotColOff, expectedColOff))
+			}
 		}
 	}
 }
-
-// func TestSetCursorY(t *testing.T) {
-// 	tests := []struct {
-// 		description    string
-// 		yDest          int
-// 		rowOff         int
-// 		expectedRowOff int
-// 		cursor         int
-// 		expectedCursor int
-// 		// runeAtCursor rune
-// 		// expectedRuneAtCursor rune
-// 		text []rune
-// 	}{
-// 		{
-// 			description: "Set cursor y to first line",
-// 			yDest:       0,
-// 		},
-// 		{
-// 			description: "Set cursor y to last line",
-// 		},
-// 		{
-// 			description: "Set cursor y out of bounds, negative",
-// 		},
-// 		{
-// 			description: "Set cursor y out of bounds, positive",
-// 		},
-// 		{
-// 			description: "Set cursor y to start of editor window",
-// 		},
-// 		{
-// 			description: "Set cursor y to end of editor window",
-// 		},
-// 	}
-
-// 	e := NewEditor()
-
-// 	for _, tc := range tests {
-// 		e.Cursor = tc.cursor
-// 		e.Text = tc.text
-
-// 		e.setCursorY(tc.yDest)
-
-// 		got := e.Cursor
-// 		expected := tc.expectedCursor
-
-// 		if !cmp.Equal(got, expected) {
-// 			t.Errorf("(%s) got != expected, diff: %v\n", tc.description, cmp.Diff(got, expected))
-// 		}
-// 	}
-// }

--- a/client/editor/editor_test.go
+++ b/client/editor/editor_test.go
@@ -19,7 +19,7 @@ func TestAddRune(t *testing.T) {
 		{r: 'd', cursor: 3, expected: []rune{'a', 'b', 'c', 'd', 'e'}},
 	}
 
-	e := NewEditor(true)
+	e := NewEditor(EditorConfig{})
 
 	for _, tc := range tests {
 		e.Cursor = tc.cursor
@@ -44,7 +44,7 @@ func TestCalcCursorXY(t *testing.T) {
 		{description: "large number", cursor: 100000, expectedX: 5, expectedY: 2},
 	}
 
-	e := NewEditor(true)
+	e := NewEditor(EditorConfig{})
 	e.Text = []rune("content\ntest")
 
 	for _, tc := range tests {
@@ -146,7 +146,7 @@ func TestMoveCursor(t *testing.T) {
 			text: []rune("\n\n\n\n\n")},
 	}
 
-	e := NewEditor(true)
+	e := NewEditor(EditorConfig{})
 
 	for _, tc := range tests {
 		e.Cursor = tc.cursor
@@ -219,7 +219,7 @@ func TestScroll(t *testing.T) {
 				text: []rune("abcdefgh\nijk")},
 		}
 
-		e := NewEditor(true)
+		e := NewEditor(EditorConfig{})
 		e.Width = 5
 		e.Height = 5
 

--- a/client/editor/editor_test.go
+++ b/client/editor/editor_test.go
@@ -219,7 +219,9 @@ func TestScroll(t *testing.T) {
 				text: []rune("abcdefgh\nijk")},
 		}
 
-		e := NewEditor(EditorConfig{})
+		e := NewEditor(EditorConfig{
+			ScrollEnabled: true,
+		})
 		e.Width = 5
 		e.Height = 5
 

--- a/client/editor/editor_test.go
+++ b/client/editor/editor_test.go
@@ -143,6 +143,9 @@ func TestMoveCursor(t *testing.T) {
 			text: []rune("\n\n\n\n\n")},
 		{description: "move down (from empty line to empty line 2)", cursor: 2, y: 1, expectedCursor: 3,
 			text: []rune("\n\n\n\n\n")},
+		//TODO: Tests to add:
+		// moving cursor down at bottom of screen causing scroll
+		// moving cursor up at top causing scroll
 	}
 
 	e := NewEditor()
@@ -160,3 +163,119 @@ func TestMoveCursor(t *testing.T) {
 		}
 	}
 }
+
+func TestScroll(t *testing.T) {
+	{
+		tests := []struct {
+			description    string
+			scrollAmt      int
+			rowOff         int
+			expectedRowOff int
+			cursor         int
+			expectedCursor int
+			// runeAtCursor rune
+			// expectedRuneAtCursor rune
+			text []rune
+		}{
+			{description: "normal scroll down",
+				scrollAmt: 1,
+				rowOff:    0, expectedRowOff: 1,
+				cursor: 0, expectedCursor: 2,
+				// runeAtCursor: a, expectedRuneAtCursor: ,
+				text: []rune("a\nb\nc\nd\ne\nf\ng\n")},
+
+			{description: "normal scroll up",
+				scrollAmt: -1,
+				rowOff:    1, expectedRowOff: 0,
+				cursor: 2, expectedCursor: 2,
+				text: []rune("a\nb\nc\nd\ne\nf\ng\n")},
+
+			{description: "normal scroll up",
+				scrollAmt: -1,
+				rowOff:    1, expectedRowOff: 0,
+				cursor: 0, expectedCursor: 0,
+				text: []rune("a\nb\nc\nd\ne\nf\ng\n")},
+			//TODO: tests to add:
+			// scrolling down with short text is rejected
+			// scrolling up at top is rejected
+			// scrolling down with cursor at top keeps cursor in same place
+			// scrolling
+		}
+
+		e := NewEditor()
+		e.Width = 80
+		e.Height = 5
+
+		for _, tc := range tests {
+			e.RowOff = tc.rowOff
+			e.Cursor = tc.cursor
+			e.Text = tc.text
+
+			e.Scroll(tc.scrollAmt)
+
+			gotCursor := e.Cursor
+			expectedCursor := tc.expectedCursor
+
+			if !cmp.Equal(gotCursor, expectedCursor) {
+				t.Errorf("(%s) Wrong cursor: got != expected, diff: %v\n", tc.description, cmp.Diff(gotCursor, expectedCursor))
+			}
+
+			gotRowOff := e.RowOff
+			expectedRowOff := tc.expectedRowOff
+
+			if !cmp.Equal(gotRowOff, expectedRowOff) {
+				t.Errorf("(%s) Wrong offset: got != expected, diff: %v\n", tc.description, cmp.Diff(gotRowOff, expectedRowOff))
+			}
+		}
+	}
+}
+
+// func TestSetCursorY(t *testing.T) {
+// 	tests := []struct {
+// 		description    string
+// 		yDest          int
+// 		rowOff         int
+// 		expectedRowOff int
+// 		cursor         int
+// 		expectedCursor int
+// 		// runeAtCursor rune
+// 		// expectedRuneAtCursor rune
+// 		text []rune
+// 	}{
+// 		{
+// 			description: "Set cursor y to first line",
+// 			yDest:       0,
+// 		},
+// 		{
+// 			description: "Set cursor y to last line",
+// 		},
+// 		{
+// 			description: "Set cursor y out of bounds, negative",
+// 		},
+// 		{
+// 			description: "Set cursor y out of bounds, positive",
+// 		},
+// 		{
+// 			description: "Set cursor y to start of editor window",
+// 		},
+// 		{
+// 			description: "Set cursor y to end of editor window",
+// 		},
+// 	}
+
+// 	e := NewEditor()
+
+// 	for _, tc := range tests {
+// 		e.Cursor = tc.cursor
+// 		e.Text = tc.text
+
+// 		e.setCursorY(tc.yDest)
+
+// 		got := e.Cursor
+// 		expected := tc.expectedCursor
+
+// 		if !cmp.Equal(got, expected) {
+// 			t.Errorf("(%s) got != expected, diff: %v\n", tc.description, cmp.Diff(got, expected))
+// 		}
+// 	}
+// }

--- a/client/editor/editor_test.go
+++ b/client/editor/editor_test.go
@@ -203,6 +203,20 @@ func TestScroll(t *testing.T) {
 				rowOff: 0, expectedRowOff: 0,
 				cursor: 1, expectedCursor: 0,
 				text: []rune("abcde")},
+
+			{description: "horizontal jump backwards",
+				x:      1,
+				colOff: 4, expectedColOff: 0,
+				rowOff: 0, expectedRowOff: 0,
+				cursor: 8, expectedCursor: 9,
+				text: []rune("abcdefgh\nijk")},
+
+			{description: "horizontal jump forwards",
+				x:      -1,
+				colOff: 0, expectedColOff: 4,
+				rowOff: 0, expectedRowOff: 0,
+				cursor: 9, expectedCursor: 8,
+				text: []rune("abcdefgh\nijk")},
 		}
 
 		e := NewEditor()
@@ -228,14 +242,14 @@ func TestScroll(t *testing.T) {
 			expectedRowOff := tc.expectedRowOff
 
 			if !cmp.Equal(gotRowOff, expectedRowOff) {
-				t.Errorf("(%s) Wrong offset: got != expected, diff: %v\n", tc.description, cmp.Diff(gotRowOff, expectedRowOff))
+				t.Errorf("(%s) Wrong row offset: got != expected, diff: %v\n", tc.description, cmp.Diff(gotRowOff, expectedRowOff))
 			}
 
 			gotColOff := e.ColOff
 			expectedColOff := tc.expectedColOff
 
 			if !cmp.Equal(gotColOff, expectedColOff) {
-				t.Errorf("(%s) Wrong offset: got != expected, diff: %v\n", tc.description, cmp.Diff(gotColOff, expectedColOff))
+				t.Errorf("(%s) Wrong col offset: got != expected, diff: %v\n", tc.description, cmp.Diff(gotColOff, expectedColOff))
 			}
 		}
 	}

--- a/client/engine.go
+++ b/client/engine.go
@@ -85,6 +85,14 @@ func handleTermboxEvent(ev termbox.Event, conn *websocket.Conn) error {
 		case termbox.KeyArrowDown, termbox.KeyCtrlN:
 			e.MoveCursor(0, 1)
 
+		// The default key for scrolling down by one line is Ctrl+D.
+		case termbox.KeyCtrlD:
+			e.Scroll(1)
+
+		// The default key for scrolling up by one line is Ctrl+U.
+		case termbox.KeyCtrlU:
+			e.Scroll(-1)
+
 		// Home key, moves cursor to initial position (X=0).
 		case termbox.KeyHome:
 			e.SetX(0)

--- a/client/engine.go
+++ b/client/engine.go
@@ -226,10 +226,19 @@ func handleMsg(msg commons.Message, conn *websocket.Conn) {
 			if err != nil {
 				logger.Errorf("failed to insert, err: %v\n", err)
 			}
+
+			e.SetText(crdt.Content(doc))
+			if msg.Operation.Position-1 <= e.Cursor {
+				e.MoveCursor(len(msg.Operation.Value), 0)
+			}
 			logger.Infof("REMOTE INSERT: %s at position %v\n", msg.Operation.Value, msg.Operation.Position)
 
 		case "delete":
 			_ = doc.Delete(msg.Operation.Position)
+			e.SetText(crdt.Content(doc))
+			if msg.Operation.Position-1 <= e.Cursor {
+				e.MoveCursor(-len(msg.Operation.Value), 0)
+			}
 			logger.Infof("REMOTE DELETE: position %v\n", msg.Operation.Position)
 		}
 	}
@@ -240,7 +249,6 @@ func handleMsg(msg commons.Message, conn *websocket.Conn) {
 	// This is to ensure that the debug logs don't take up much space on the user's filesystem, and can be toggled on demand.
 	printDoc(doc)
 
-	e.SetText(crdt.Content(doc))
 	e.Draw()
 }
 

--- a/client/engine.go
+++ b/client/engine.go
@@ -85,14 +85,6 @@ func handleTermboxEvent(ev termbox.Event, conn *websocket.Conn) error {
 		case termbox.KeyArrowDown, termbox.KeyCtrlN:
 			e.MoveCursor(0, 1)
 
-		// The default key for scrolling down by one line is Ctrl+D.
-		case termbox.KeyCtrlD:
-			e.Scroll(1)
-
-		// The default key for scrolling up by one line is Ctrl+U.
-		case termbox.KeyCtrlU:
-			e.Scroll(-1)
-
 		// Home key, moves cursor to initial position (X=0).
 		case termbox.KeyHome:
 			e.SetX(0)

--- a/client/main.go
+++ b/client/main.go
@@ -21,7 +21,7 @@ var (
 	logger = logrus.New()
 
 	// termbox-based editor.
-	e = editor.NewEditor(false)
+	e = editor.NewEditor(editor.EditorConfig{})
 
 	// The name of the file to load from and save to.
 	fileName string
@@ -74,7 +74,13 @@ func main() {
 		}
 	}
 
-	err = initUI(conn, flags.Scroll)
+	uiConfig := UIConfig{
+		EditorConfig: editor.EditorConfig{
+			ScrollEnabled: flags.Scroll,
+		},
+	}
+
+	err = initUI(conn, uiConfig)
 	if err != nil {
 		// If error has the prefix "pairpad", then it was triggered by an event that wasn't an error, for example, exiting the editor.
 		// It's a hacky solution since the UI returns an error only.

--- a/client/main.go
+++ b/client/main.go
@@ -74,7 +74,7 @@ func main() {
 		}
 	}
 
-	err = UI(conn)
+	err = initUI(conn)
 	if err != nil {
 		// If error has the prefix "pairpad", then it was triggered by an event that wasn't an error, for example, exiting the editor.
 		// It's a hacky solution since the UI returns an error only.

--- a/client/main.go
+++ b/client/main.go
@@ -21,7 +21,7 @@ var (
 	logger = logrus.New()
 
 	// termbox-based editor.
-	e = editor.NewEditor()
+	e = editor.NewEditor(false)
 
 	// The name of the file to load from and save to.
 	fileName string
@@ -74,7 +74,7 @@ func main() {
 		}
 	}
 
-	err = initUI(conn)
+	err = initUI(conn, flags.Scroll)
 	if err != nil {
 		// If error has the prefix "pairpad", then it was triggered by an event that wasn't an error, for example, exiting the editor.
 		// It's a hacky solution since the UI returns an error only.

--- a/client/ui.go
+++ b/client/ui.go
@@ -10,14 +10,14 @@ import (
 // termbox allows us to set any content to individual cells, and hence, the basic building block of the editor is a "cell".
 
 // initUI creates a new editor view and runs the main loop.
-func initUI(conn *websocket.Conn) error {
+func initUI(conn *websocket.Conn, scrollEnabled bool) error {
 	err := termbox.Init()
 	if err != nil {
 		return err
 	}
 	defer termbox.Close()
 
-	e = editor.NewEditor()
+	e = editor.NewEditor(scrollEnabled)
 	e.SetSize(termbox.Size())
 	e.Draw()
 

--- a/client/ui.go
+++ b/client/ui.go
@@ -9,8 +9,8 @@ import (
 // TUI is built using termbox-go.
 // termbox allows us to set any content to individual cells, and hence, the basic building block of the editor is a "cell".
 
-// UI creates a new editor view and runs the main loop.
-func UI(conn *websocket.Conn) error {
+// initUI creates a new editor view and runs the main loop.
+func initUI(conn *websocket.Conn) error {
 	err := termbox.Init()
 	if err != nil {
 		return err
@@ -18,6 +18,7 @@ func UI(conn *websocket.Conn) error {
 	defer termbox.Close()
 
 	e = editor.NewEditor()
+	e.Logger.Print("NEW SESH")
 	e.SetSize(termbox.Size())
 	e.Draw()
 

--- a/client/ui.go
+++ b/client/ui.go
@@ -18,7 +18,6 @@ func initUI(conn *websocket.Conn) error {
 	defer termbox.Close()
 
 	e = editor.NewEditor()
-	e.Logger.Print("NEW SESH")
 	e.SetSize(termbox.Size())
 	e.Draw()
 

--- a/client/ui.go
+++ b/client/ui.go
@@ -6,18 +6,22 @@ import (
 	"github.com/nsf/termbox-go"
 )
 
+type UIConfig struct {
+	EditorConfig editor.EditorConfig
+}
+
 // TUI is built using termbox-go.
 // termbox allows us to set any content to individual cells, and hence, the basic building block of the editor is a "cell".
 
 // initUI creates a new editor view and runs the main loop.
-func initUI(conn *websocket.Conn, scrollEnabled bool) error {
+func initUI(conn *websocket.Conn, conf UIConfig) error {
 	err := termbox.Init()
 	if err != nil {
 		return err
 	}
 	defer termbox.Close()
 
-	e = editor.NewEditor(scrollEnabled)
+	e = editor.NewEditor(conf.EditorConfig)
 	e.SetSize(termbox.Size())
 	e.Draw()
 

--- a/client/utils.go
+++ b/client/utils.go
@@ -23,6 +23,7 @@ type Flags struct {
 	Login  bool
 	File   string
 	Debug  bool
+	Scroll bool
 }
 
 // parseFlags parses command-line flags.
@@ -32,6 +33,7 @@ func parseFlags() Flags {
 	enableDebug := flag.Bool("debug", false, "Enable debugging mode to show more verbose logs")
 	enableLogin := flag.Bool("login", false, "Enable the login prompt for the server")
 	file := flag.String("file", "", "The file to load the pairpad content from")
+	enableScroll := flag.Bool("scroll", true, "Enable scrolling with the cursor")
 
 	flag.Parse()
 
@@ -41,6 +43,7 @@ func parseFlags() Flags {
 		Debug:  *enableDebug,
 		Login:  *enableLogin,
 		File:   *file,
+		Scroll: *enableScroll,
 	}
 }
 


### PR DESCRIPTION
Remote insertions/deletions now update the local cursor position so that it stays in the correct place, making it nicer for multiple people to edit at the same time.

Moving the cursor off the edge of the editor window now shifts the window to stay with the cursor. This is a minimal implementation of scrolling, equivalent to the behavior of the [kilo](github.com/antirez/kilo) editor.

Both features seem to work, and I wrote a few tests, but there could definitely be edge cases I haven't thought of. I'm planning to keep adding tests.